### PR TITLE
chore: use latest ubuntu runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Test
 on: [push]
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js 12.8


### PR DESCRIPTION
Use latest `ubuntu` runner since `ubuntu-18.04` has been deprecated.